### PR TITLE
Improve Windows installation docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ Real end‑to‑end tests require API keys. Review `TESTING_GUIDE.md` for enviro
 
 ## Adding Documentation
 
-New Portuguese lessons should be placed in the appropriate numbered folder under `docs_translations/pt-br`. Update `docs_translations/pt-br/README.md` to keep the index current.
+New Portuguese lessons should be placed in the appropriate numbered folder under `docs_translations/pt-br`. Update `docs_translations/pt-br/README.md` to keep the index current. When expanding existing material, incorpore detalhes e tecnologias recentes (2024/2025) para ampliar o entendimento do usuário, conforme o plano em `docs_translations/pt-br/plan.md`.
 
 ## Open Improvements
 

--- a/docs_translations/pt-br/01_instalacao/00_instalacao_windows.md
+++ b/docs_translations/pt-br/01_instalacao/00_instalacao_windows.md
@@ -79,10 +79,25 @@ Esta é a forma recomendada para a maioria dos usuários que desejam utilizar o 
 
 *   **`praisonai` (Pacote completo com CLI e modo "No Code"):**
     Se você quer a experiência completa, incluindo a interface de linha de comando (CLI) para executar arquivos YAML e o modo automático.
-    ```bash
+```bash
     pip install praisonai
-    ```
+```
     Este pacote geralmente inclui `praisonaiagents` como dependência.
+
+#### Recursos adicionais (2024/2025)
+
+As versões mais recentes do PraisonAI tiram proveito de aprimoramentos do **Python 3.11+**,
+portanto mantenha seu interpretador atualizado para ganhar desempenho e compatibilidade.
+
+Além do `pip`, considere usar **`pipx`** para instalar o `praisonai` de forma isolada
+(`pipx install praisonai`). Isso facilita o gerenciamento de versões da CLI sem poluir
+seu ambiente principal.
+
+Para testes com modelos locais ou de código aberto, como os fornecidos pelo **Ollama** ou
+**LM Studio**, defina `OPENAI_BASE_URL` apontando para o servidor local e especifique
+`OPENAI_MODEL_NAME` com o modelo desejado (por exemplo, `llama3:latest`). Se você dispõe
+de GPU, bibliotecas atualizadas como **PyTorch 2.2** e **TensorRT** ajudam a acelerar a
+inferência em 2025.
 
 ### 2. Para Desenvolvedores (Trabalhando com o Código Fonte)
 

--- a/docs_translations/pt-br/plan.md
+++ b/docs_translations/pt-br/plan.md
@@ -49,6 +49,8 @@ Este arquivo resume os módulos já existentes na documentação em `docs/pt-br`
 -  - (concluído) Callback Agents
 -  - (concluído) Mini AI Agents
 - Documentar a estrutura do código e exemplos de YAML (concluído)
+- (atualizado) Guia de instalação no Windows expandido com recomendações de 2024/2025.
+- Revisar todos os módulos para incorporar novidades recentes (Python 3.11+, pipx, modelos locais com Ollama/LM Studio e otimizações de GPU).
 
 
 Este plano deve ser atualizado sempre que novos módulos ou seções forem criados.


### PR DESCRIPTION
## Summary
- expand Windows install guide with Python 3.11+ and local model tips
- note doc expansion in AGENTS guidelines
- record new tasks in `plan.md`

## Testing
- `python src/praisonai/tests/simple_test_runner.py --fast`


------
https://chatgpt.com/codex/tasks/task_e_6845e75913c48327aa917c93a6fa1ac5