### PR TITLE
Add Linux/macOS install guides

### DIFF
--- a/docs_translations/pt-br/01_instalacao/01_instalacao_linux.md
+++ b/docs_translations/pt-br/01_instalacao/01_instalacao_linux.md
@@ -1,0 +1,46 @@
+# Guia de Instalação Local (Linux)
+
+Este documento explica como preparar um ambiente Linux para executar o PraisonAI. Siga os passos para configurar variáveis de ambiente, instalar o Python 3.11 ou superior e usar `pipx` para a CLI.
+
+## Pré‑requisitos
+
+1. **Python 3.11+**
+   - Verifique sua versão:
+     ```bash
+     python3 --version
+     ```
+   - A maioria das distribuições já possui pacotes atualizados. Se precisar, use `apt`, `dnf` ou `pacman` (dependendo da distro) ou instale com [`pyenv`](https://github.com/pyenv/pyenv).
+2. **Git** (opcional, para clonar o repositório).
+
+## Configurando Variáveis de Ambiente
+
+Defina `OPENAI_API_KEY` para acessar modelos comerciais ou utilize `OPENAI_BASE_URL` e `OPENAI_MODEL_NAME` para modelos locais (ex.: Ollama ou LM Studio). Para exportar temporariamente:
+```bash
+export OPENAI_API_KEY=sua_chave
+```
+Coloque essas linhas no arquivo `~/.bashrc` ou `~/.zshrc` para torná‑las permanentes.
+
+## Instalando o PraisonAI
+
+O método mais simples é usar `pipx` para isolar a CLI:
+```bash
+python3 -m pip install --user pipx
+pipx install praisonai
+```
+Isso instala a ferramenta sem interferir em outros projetos Python. Se preferir, use ambientes virtuais e o `pip` padrão.
+
+Para executar com modelos locais, defina:
+```bash
+export OPENAI_BASE_URL=http://localhost:11434/v1
+export OPENAI_MODEL_NAME=llama3:latest
+```
+Assim a CLI utilizará o servidor Ollama/LM Studio.
+
+### Uso Básico
+
+Depois da instalação, teste no terminal:
+```bash
+praisonai --auto "Explique o que é um agente autônomo."
+```
+Se ocorrerem erros de importação, verifique se `pipx` adicionou sua pasta de executáveis ao `PATH`.
+

--- a/docs_translations/pt-br/01_instalacao/02_instalacao_macos.md
+++ b/docs_translations/pt-br/01_instalacao/02_instalacao_macos.md
@@ -1,0 +1,46 @@
+# Guia de Instalação Local (macOS)
+
+Este guia descreve como preparar o PraisonAI em sistemas macOS recentes.
+
+## Pré‑requisitos
+
+1. **Python 3.11+**
+   - O macOS Ventura ou superior já traz Python 3 instalado via Xcode Command Line Tools. Verifique com:
+     ```bash
+     python3 --version
+     ```
+   - Se necessário, instale versões atualizadas com [Homebrew](https://brew.sh/):
+     ```bash
+     brew install python@3.11
+     ```
+2. **Homebrew** para instalar dependências facilmente.
+3. **Git** (opcional, para clonar o repositório).
+
+## Configurando Variáveis de Ambiente
+
+Abra o Terminal e exporte sua `OPENAI_API_KEY` ou, para modelos locais, configure `OPENAI_BASE_URL` e `OPENAI_MODEL_NAME`. Acrescente as linhas ao `~/.zshrc`:
+```bash
+export OPENAI_API_KEY=sua_chave
+# ou para Ollama/LM Studio
+export OPENAI_BASE_URL=http://localhost:11434/v1
+export OPENAI_MODEL_NAME=llama3:latest
+```
+Reabra o Terminal ou execute `source ~/.zshrc` para aplicar.
+
+## Instalando o PraisonAI com `pipx`
+
+`pipx` permite instalar a CLI de forma isolada:
+```bash
+python3 -m pip install --user pipx
+pipx install praisonai
+```
+Caso encontre erros de permissão, garanta que a pasta `~/Library/Python/3.x/bin` esteja no `PATH`.
+
+### Teste Rápido
+
+Execute:
+```bash
+praisonai --auto "Gere um resumo sobre PraisonAI"
+```
+Se tudo correr bem, a resposta aparecerá no terminal. Para desenvolvimento, você também pode clonar o repositório e instalar em modo editável com `pip` ou `uv`.
+

--- a/docs_translations/pt-br/README.md
+++ b/docs_translations/pt-br/README.md
@@ -9,6 +9,9 @@ Navegue pelos módulos à esquerda para começar sua jornada de aprendizado. Cad
 *   **Introdução:** Visão geral do PraisonAI e desta documentação.
 *   **Metodologia de Aprendizado:** Orientações científicas para estudar com eficiência.
 *   **Instalação:** Como instalar o PraisonAI em seu ambiente.
+    * [Windows](01_instalacao/00_instalacao_windows.md)
+    * [Linux](01_instalacao/01_instalacao_linux.md)
+    * [macOS](01_instalacao/02_instalacao_macos.md)
 *   **Conceitos Fundamentais:** Os blocos de construção do PraisonAI.
 *   **Usando o PraisonAI:** Guias práticos para Python, YAML e JavaScript/TypeScript.
 *   **Guia Rápido: Criando Seu Primeiro Agente:** Passo a passo para colocar um agente em funcionamento.

--- a/docs_translations/pt-br/plan.md
+++ b/docs_translations/pt-br/plan.md
@@ -36,7 +36,7 @@ Este arquivo resume os módulos já existentes na documentação em `docs/pt-br`
 
 ## Pontos a Desenvolver
 
-- Adicionar instruções de instalação para Linux e macOS.
+- (concluído) Instruções de instalação para Linux e macOS.
 - Explorar exemplos mais detalhados de ferramentas e memórias avançadas.
 - Criar exercícios práticos adicionais para fixação dos conceitos.
 - Documentar integrações específicas com outros provedores de LLM (ex.: Gemini, Anthropic).


### PR DESCRIPTION
## Summary
- add Linux and macOS installation docs
- reference them from the PT-BR README
- mark install docs as completed in plan

## Testing
- `python src/praisonai/tests/simple_test_runner.py --fast` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6845e9ab07bc8327a3e12dae49a46524