### PR TITLE
Add Gemini and Anthropic setup details

### DIFF
--- a/docs_translations/pt-br/06_modelos_llm/00_usando_diferentes_llms.md
+++ b/docs_translations/pt-br/06_modelos_llm/00_usando_diferentes_llms.md
@@ -65,13 +65,43 @@ Groq fornece inferência de LLM em alta velocidade usando seus LPUs (Language Pr
 ### 4. Google Gemini
 
 *   **Pré-requisito:** Ter uma chave de API do Google AI Studio ou configurado para usar Gemini via Vertex AI no Google Cloud.
-*   **Variáveis de Ambiente:** A configuração exata pode variar (ex: `GOOGLE_API_KEY`). O PraisonAI pode ter um manipulador específico para Gemini.
-*   **Recomendação:** Consulte a documentação oficial do PraisonAI ou exemplos específicos sobre como integrar modelos Gemini, pois pode haver um fluxo de configuração um pouco diferente do padrão `OPENAI_*`.
+*   **Variável de Ambiente Principal:**
+    ```bash
+    export GOOGLE_API_KEY="sua_chave_do_google"
+    ```
+*   **(Opcional)** se utilizar serviços no Google Cloud, defina `GOOGLE_APPLICATION_CREDENTIALS` apontando para o arquivo JSON da service account.
+*   **Exemplo de Configuração no Agente:**
+    ```yaml
+    llm:
+      provider: google
+      model: "gemini-pro"
+    ```
+    ```python
+    agente_gemini = Agent(role="Assistente Gemini", llm="google/gemini-pro")
+    ```
+*   **Custos:** Há uma cota gratuita limitada. Após excedê-la, o Gemini Pro custa em torno de **US$0,0025** por 1k tokens de entrada e **US$0,0075** por 1k tokens de saída (valores de 2024). Consulte o painel do Google AI para preços atualizados.
 
-### 5. Outros Modelos (Anthropic Claude, Cohere, etc.)
+### 5. Anthropic (Claude)
+
+*   **Variável de Ambiente Principal:**
+    ```bash
+    export ANTHROPIC_API_KEY="sua_chave_da_anthropic"
+    ```
+*   **Exemplo de Configuração no Agente:**
+    ```yaml
+    llm:
+      provider: anthropic
+      model: "claude-3-sonnet-20240229"
+    ```
+    ```python
+    agente_claude = Agent(role="Assistente Claude", llm="anthropic/claude-3-sonnet-20240229")
+    ```
+*   **Custos:** Os modelos Claude 3 variam de preço. O Claude 3 Opus, por exemplo, custa cerca de **US$15** por milhão de tokens de entrada e **US$75** por milhão de tokens de saída. Veja [anthropic.com/pricing](https://www.anthropic.com/pricing) para valores atualizados.
+
+### 6. Outros Modelos (Cohere, DeepSeek, etc.)
 
 PraisonAI visa suportar uma ampla gama de modelos. A configuração para cada um pode envolver:
-*   Variáveis de ambiente específicas (ex: `ANTHROPIC_API_KEY`).
+*   Variáveis de ambiente específicas (ex: `COHERE_API_KEY`, `DEEPSEEK_API_KEY`).
 *   Uso de URLs base específicas se eles expõem uma API compatível com OpenAI.
 *   Manipuladores (handlers) ou clientes específicos dentro do PraisonAI para esses modelos.
 


### PR DESCRIPTION
### **User description**
## Summary
- expand instructions for using Google Gemini models
- add dedicated section for Anthropic Claude models
- clarify other model environment variables

## Testing
- `python src/praisonai/tests/simple_test_runner.py --fast` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6845ee908efc83278be0ccd33354a0c9


___

### **PR Type**
Documentation


___

### **Description**
- Expanded setup instructions for Google Gemini models.

- Added dedicated section for Anthropic Claude model setup.

- Clarified environment variables for various LLM providers.

- Updated pricing and configuration examples for Gemini and Claude.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>00_usando_diferentes_llms.md</strong><dd><code>Expanded Gemini and Anthropic setup, clarified LLM environment </code><br><code>variables</code></dd></summary>
<hr>

docs_translations/pt-br/06_modelos_llm/00_usando_diferentes_llms.md

<li>Expanded Google Gemini setup details and examples.<br> <li> Added new section for Anthropic Claude, including config and pricing.<br> <li> Clarified environment variables for Cohere, DeepSeek, and others.<br> <li> Updated pricing information for Gemini and Claude models.


</details>


  </td>
  <td><a href="https://github.com/Habdel-Edenfield/Habook-AI/pull/22/files#diff-66cbefc9d39c0abb799fa18ddc5676ba1ff9c2571d6601b1cec485a73294e8a2">+34/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>